### PR TITLE
fix: validation for optional data structures

### DIFF
--- a/src/apps/application.ts
+++ b/src/apps/application.ts
@@ -4,7 +4,10 @@ import {PersistentClient} from '../persistentClient'
 import {generateRandomSourceId, Result} from '../utils'
 
 const _getJoinableTransportId = (status: ReceiverStatus): Result<string> => {
-  const app = status.applications.find(a => a.namespaces.map(e => e.name).includes('urn:x-cast:com.google.cast.media'))
+  const app =
+    status.applications === undefined
+      ? undefined
+      : status.applications.find(a => a.namespaces.map(e => e.name).includes('urn:x-cast:com.google.cast.media'))
   return app === undefined ? Result.Err(new Error('failed to find joinable application')) : Result.Ok(app.transportId)
 }
 

--- a/src/cast-types/index.ts
+++ b/src/cast-types/index.ts
@@ -33,7 +33,7 @@ export const Application$ = z.object({
 export type Application = z.infer<typeof Application$>
 
 export const ReceiverStatus$ = z.object({
-  applications: z.array(Application$),
+  applications: z.array(Application$).optional(),
   volume: Volume$,
 })
 export type ReceiverStatus = z.infer<typeof ReceiverStatus$>

--- a/src/cast-types/media.types.ts
+++ b/src/cast-types/media.types.ts
@@ -37,6 +37,6 @@ export const MediaStatus$ = z.object({
   playbackRate: z.number(),
   playerState: PlayerState$,
   supportedMediaCommands: z.number(), // sum of SupportedMediaCommands
-  volume: Volume$,
+  volume: Volume$.nullish(),
 })
 export type MediaStatus = z.infer<typeof MediaStatus$>


### PR DESCRIPTION
Plex does not return `volume` which causes `MediaController.getStatus` to throw an error due to zod validation failing, but the api call did succeed.

I suspect other applications may also not allow volume control.