### PR TITLE
feat: Richer and more human-readable validation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "castv2": "^0.1.10",
         "debug": "^4.3.4",
-        "zod": "^3.20.2"
+        "zod": "^3.20.2",
+        "zod-validation-error": "^2.1.0"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -3120,6 +3121,17 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
+      }
     }
   },
   "dependencies": {
@@ -5378,6 +5390,12 @@
       "version": "3.20.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
       "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ=="
+    },
+    "zod-validation-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "castv2": "^0.1.10",
     "debug": "^4.3.4",
-    "zod": "^3.20.2"
+    "zod": "^3.20.2",
+    "zod-validation-error": "^2.1.0"
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import {z} from 'zod'
+import * as zod from 'zod'
+import {ValidationError} from 'zod-validation-error'
 
 export class Result<T, E = Error> {
   private constructor(private value: {isOk: true; value: T} | {isOk: false; value: E}) {}
@@ -53,11 +55,27 @@ export const withTimeout =
       }),
     ])
 
-export const tryParseJSON = (s: string | Buffer): Record<string, unknown> | undefined => {
+export const tryParseJSON = (s: string | Buffer): MaybeJson => {
   try {
     const o = JSON.parse(s.toString())
     if (o && typeof o === 'object') return o
   } catch {
     return undefined
   }
+}
+
+type MaybeJson = Record<string, unknown> | undefined
+
+export class ContextualValidationError extends ValidationError {
+  data: MaybeJson | string
+  constructor(message: string, data: MaybeJson | string, details?: Array<zod.ZodIssue> | undefined) {
+    super(message, details)
+    this.data = data
+  }
+}
+
+export const fromValidationError = (err: ValidationError, data: MaybeJson | string): ContextualValidationError => {
+  const cError = new ContextualValidationError(err.message, data, err.details)
+  cError.stack = err.stack
+  return cError
 }


### PR DESCRIPTION
* Use zod-validation-error to format error message for zod validation failure error as human readable
* Wrap validation error in child class that provides raw channel response json/string to make debugging and recovery easier

Closes #15