### PR TITLE
refactor: Refactor PersistentClient as a class instead of function

### DIFF
--- a/examples/errorHandling.ts
+++ b/examples/errorHandling.ts
@@ -1,6 +1,7 @@
-import {createPlatform, connect} from '../src'
+import {createPlatform, PersistentClient} from '../src'
 ;(async () => {
-  const client = await connect({host: '192.168.1.150'})
+  const client = new PersistentClient({host: '192.168.1.150'})
+  await client.connect()
   const platform = await createPlatform(client)
   const status = await platform.getStatus()
 

--- a/examples/mediaApp.ts
+++ b/examples/mediaApp.ts
@@ -1,7 +1,8 @@
-import {DefaultMediaApp, connect, Result} from '../src'
+import {DefaultMediaApp, PersistentClient, Result} from '../src'
 ;(async () => {
   // create a persistent client connected on a given host
-  const client = await connect({host: '192.168.1.150'})
+  const client = new PersistentClient({host: '192.168.1.150'})
+  await client.connect()
 
   // launch the media app on the Chromecast and join the session (so we can control the CC)
   const media = await DefaultMediaApp.launchAndJoin({client}).then(Result.unwrapWithErr)

--- a/examples/mediaController.ts
+++ b/examples/mediaController.ts
@@ -1,7 +1,8 @@
-import {connect, ReceiverController} from '../src'
+import {PersistentClient, ReceiverController} from '../src'
 ;(async () => {
   // create a persistent client connected on a given host
-  const client = await connect({host: '192.168.1.150'})
+  const client = new PersistentClient({host: '192.168.1.150'})
+  await client.connect()
 
   // launch the media app on the Chromecast and join the session (so we can control the CC)
   const controller = ReceiverController.createReceiver({client})

--- a/examples/platform.ts
+++ b/examples/platform.ts
@@ -1,6 +1,7 @@
-import {createPlatform, connect} from '../src'
+import {createPlatform, PersistentClient} from '../src'
 ;(async () => {
-  const client = await connect({host: '192.168.1.150'})
+  const client = new PersistentClient({host: '192.168.1.150'})
+  await client.connect()
   const platform = await createPlatform(client)
   const status = await platform.getStatus()
   console.log('current status', status)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from './cast-types'
 export {Channel} from './channel'
-export {connect, PersistentClient} from './persistentClient'
+export {PersistentClient, connect} from './persistentClient'
 export {createPlatform} from './platform'
 export {Result} from './utils'
 export * as ReceiverController from './controllers/receiver'

--- a/src/persistentClient.ts
+++ b/src/persistentClient.ts
@@ -1,3 +1,6 @@
+import {EventEmitter} from 'events'
+import {clearInterval} from 'node:timers'
+
 import {Client} from 'castv2'
 import Debug from 'debug'
 
@@ -5,63 +8,101 @@ import {createChannel} from './channel'
 import {withTimeout} from './utils'
 const debug = Debug('persistent-client')
 
-export type PersistentClient = {
-  close: () => void
-  send: Client['send']
-  createChannel: ReturnType<typeof createChannel>
-}
-
-export const connect = ({
-  host,
-  client = new Client(),
-  retryDelay = 5000,
-  port = 8009,
-  timeout = 3000,
-}: {
+export interface PersistentClientOptions {
   host: string
   client?: Client
   retryDelay?: number
   port?: number
   timeout?: number
-}): Promise<PersistentClient> => {
-  let shouldReconnect = true
-  let isConnected = false
+}
 
-  const close = () => {
-    debug('permanently closing client...')
-    shouldReconnect = false
-    client.close()
+export class PersistentClient extends EventEmitter {
+  client: Client
+  send: Client['send']
+  createChannel: ReturnType<typeof createChannel>
+  shouldReconnect: boolean
+  connected: boolean
+  private interval?: number
+  private options: Required<Omit<PersistentClientOptions, 'client'>>
+
+  constructor(options: PersistentClientOptions) {
+    super()
+    const {host, client = new Client(), retryDelay = 5000, port = 8009, timeout = 3000} = options
+    this.options = {
+      host,
+      retryDelay,
+      port,
+      timeout,
+    }
+    this.client = client
+    this.client.on('close', () => {
+      this.connected = false
+      this.emit('close')
+    })
+    this.client.on('error', err => {
+      this.emit('error', err)
+    })
+    this.send = this.client.send.bind(this.client)
+    this.createChannel = createChannel(this.client)
+    this.shouldReconnect = true
+    this.connected = false
   }
 
-  const sendHeartbeat = () =>
-    client.send('sender-0', 'receiver-0', 'urn:x-cast:com.google.cast.tp.heartbeat', JSON.stringify({type: 'PING'}))
-
-  const send = client.send.bind(client)
-
-  return withTimeout({timeout})(
-    new Promise(resolve => {
-      if (isConnected) return resolve({close, send, createChannel: createChannel(client)})
-
-      client.connect({host, port}, () => {
-        isConnected = true
-
-        sendHeartbeat()
-        const timer = setInterval(sendHeartbeat, 5000)
-
-        client.once('close', () => {
-          isConnected = false
-          clearInterval(timer)
-
-          if (shouldReconnect) {
-            debug(`client reconnecting in ${retryDelay}ms`)
-            setTimeout(() => {
-              connect({host, client, retryDelay, port, timeout})
-            }, retryDelay)
+  heartbeat() {
+    this.interval = setInterval(function (self) {
+      return async () => {
+        if (self.connected) {
+          self.send('sender-0', 'receiver-0', 'urn:x-cast:com.google.cast.tp.heartbeat', JSON.stringify({type: 'PING'}))
+        } else if (self.shouldReconnect) {
+          debug(`client reconnecting in ${self.options.retryDelay}ms`)
+          try {
+            await self.connect()
+          } catch (e) {
+            self.emit('error', e)
           }
-        })
+        } else {
+          clearInterval(self.interval)
+          self.interval = undefined
+        }
+      }
+    }, this.options.retryDelay)
+  }
 
-        resolve({close, send, createChannel: createChannel(client)})
-      })
-    })
-  )
+  connect = async () => {
+    if (this.connected) {
+      return
+    }
+    this.shouldReconnect = true
+    // eslint-disable-next-line no-useless-catch
+    try {
+      await withTimeout({timeout: this.options.timeout})(
+        new Promise<void>(resolve => {
+          this.client.connect({host: this.options.host, port: this.options.port}, () => {
+            this.emit('connect')
+            this.connected = true
+            if (this.interval === undefined) {
+              this.heartbeat()
+            }
+            resolve()
+          })
+        })
+      )
+    } catch (e) {
+      throw e
+    }
+  }
+
+  close = () => {
+    debug('permanently closing client...')
+    this.shouldReconnect = false
+    this.client.close()
+    clearInterval(this.interval)
+    this.interval = undefined
+  }
+}
+
+export const connect = async (options: PersistentClientOptions) => {
+  const client = new PersistentClient(options)
+  await client.connect()
+  return client
 }


### PR DESCRIPTION
* Fixes unhandled timeout rejection on `connect`
* Allows initiating `connect` separately from instantiation using `await persistentClient.connect()`
  * `connect()` is still exported at top-level to prevent breaking change
* Better reconnection logic
* is an `EventEmitter` that re-emits `castv2` events
* exposes `castv2` client, `connected` and `shouldReconnect` fields